### PR TITLE
implemented remove simulation endpoint with tests

### DIFF
--- a/cmd/server/api/api.go
+++ b/cmd/server/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -14,6 +15,7 @@ import (
 type API struct {
 	server *http.Server
 
+	mutex       *sync.Mutex
 	simulations map[string]simulation.Simulation
 }
 
@@ -21,6 +23,7 @@ type API struct {
 func NewAPI() API {
 	var a API
 	a.setup()
+	a.mutex = &sync.Mutex{}
 	a.simulations = make(map[string]simulation.Simulation)
 	return a
 }

--- a/cmd/server/api/api_test.go
+++ b/cmd/server/api/api_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"github.com/tardisman5197/barnes-hut-sim/pkg/simulation"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEndpointCreateSimulation(t *testing.T) {
+	api := NewAPI()
+
+	reqBody := NewSimulationRequest{
+		Grav:   1,
+		Theta:  0,
+		Bodies: []simulation.Body{},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := &http.Request{
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(bytes.NewBuffer(body)),
+	}
+
+	rr := httptest.NewRecorder()
+
+	api.newSimulation(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	var response NewSimulationResponse
+	if err := json.NewDecoder(rr.Result().Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+
+	if response.ID == "" {
+		t.Fatal("empty simulation ID")
+	}
+
+	if response.Simulation.Grav != reqBody.Grav {
+		t.Fatalf("expected response Grav to be %f but was %f", response.Simulation.Grav, reqBody.Grav)
+	}
+
+	if response.Simulation.Theta != reqBody.Theta {
+		t.Fatalf("expected response Theta to be %f but was %f", response.Simulation.Theta, reqBody.Theta)
+	}
+
+	currentSimulations := len(api.simulations)
+	if currentSimulations != 1{
+		t.Fatalf("expected 1 simulation, found %d", currentSimulations)
+	}
+
+}
+
+func TestEndpointRemoveSimulation(t *testing.T) {
+	api := NewAPI()
+
+	reqBody := NewSimulationRequest{
+		Grav:   1,
+		Theta:  0,
+		Bodies: []simulation.Body{},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := &http.Request{
+		Body: ioutil.NopCloser(bytes.NewBuffer(body)),
+	}
+
+	rr := httptest.NewRecorder()
+
+	api.newSimulation(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	var response NewSimulationResponse
+	if err := json.NewDecoder(rr.Result().Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+
+	if response.ID == "" {
+		t.Fatal("empty simulation ID")
+	}
+
+	currentSimulations := len(api.simulations)
+	if currentSimulations != 1{
+		t.Fatalf("expected 1 simulation, found %d", currentSimulations)
+	}
+
+	rr = httptest.NewRecorder()
+
+	request = mux.SetURLVars(&http.Request{
+		Method: http.MethodGet,
+	}, map[string]string{
+		"simID": response.ID,
+	})
+
+	api.remove(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	currentSimulations = len(api.simulations)
+	if currentSimulations != 0 {
+		t.Fatalf("expected 0 simulation, found %d", currentSimulations)
+	}
+
+}
+
+func TestRemoveNotPresentSimulation(t *testing.T) {
+	api := NewAPI()
+	rr := httptest.NewRecorder()
+
+	request := mux.SetURLVars(&http.Request{
+		Method: http.MethodGet,
+	}, map[string]string{
+		"simID": "test",
+	})
+
+	api.remove(rr, request)
+
+	if rr.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestRemoveWithoutSimID(t *testing.T) {
+	api := NewAPI()
+	rr := httptest.NewRecorder()
+
+	request := mux.SetURLVars(&http.Request{
+		Method: http.MethodGet,
+	}, map[string]string{})
+
+	api.remove(rr, request)
+
+	if rr.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusBadRequest)
+	}
+}
+
+

--- a/cmd/server/api/endpoints.go
+++ b/cmd/server/api/endpoints.go
@@ -3,22 +3,33 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/mux"
 	"net/http"
 
 	"github.com/tardisman5197/barnes-hut-sim/pkg/simulation"
 )
 
+type NewSimulationRequest struct {
+	Grav   float64           `json:"grav"`
+	Theta  float64           `json:"theta"`
+	Bodies []simulation.Body `json:"bodies,omitempty"`
+}
+
+type NewSimulationResponse struct {
+	ID         string                `json:"id"`
+	Simulation simulation.Simulation `json:"simulation"`
+}
+
 // newSimulation is called when a request is made to "/simulation/new".
 // It creates a new simulation with a unique ID and then returns the
 // details of the simulation to the requester.
 func (a *API) newSimulation(w http.ResponseWriter, r *http.Request) {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
 	fmt.Println("New Simulation Request")
 	// Read in therequest body
-	type NewSimulationRequest struct {
-		Grav   float64           `json:"grav"`
-		Theta  float64           `json:"theta"`
-		Bodies []simulation.Body `json:"bodies,omitempty"`
-	}
+
 	var req NewSimulationRequest
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
@@ -43,10 +54,7 @@ func (a *API) newSimulation(w http.ResponseWriter, r *http.Request) {
 	// Send simulation information back to the requester
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
-	type NewSimulationResponse struct {
-		ID         string                `json:"id"`
-		Simulation simulation.Simulation `json:"simulation"`
-	}
+
 	json.NewEncoder(w).Encode(
 		NewSimulationResponse{
 			ID:         id,
@@ -82,6 +90,23 @@ func (a *API) results(w http.ResponseWriter, r *http.Request) {
 // remove is called when a request is made to "/simulation/remove/{simID}".
 // This endpoint will remove the simulation with the ID requested.
 func (a *API) remove(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("Results Simulation Request")
-	w.WriteHeader(http.StatusNotImplemented)
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
+	vars := mux.Vars(r)
+
+	simID, hasSimID := vars["simID"]
+	if !hasSimID {
+		http.Error(w, "simulation id not provided", http.StatusBadRequest)
+		return
+	}
+
+	_, present := a.simulations[simID]
+	if !present {
+		http.Error(w, fmt.Sprintf("simulation with id %s not present", simID), http.StatusBadRequest)
+		return
+	}
+
+	delete(a.simulations, simID)
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
Solves #13

This pull request implements the remove endpoints with related unit tests along with some minor refactoring of the api package. 

The endpoint is implemented to answer `400 Bad Request` with relative error code in case of simulation id not passed or not present, if the provided id is present the simulation with be removed from the simulations map and the server will answer with http status code `200 Ok`.

Since we are modifing a `map` (that isn't threadsafe) through api calls I also added a `sync.Mutex` for the endpoints to avoid race conditions that may lead to crashes / undefined behaviours. 

I also added some unit tests for the CreateSimulation endpoint and extracted the `NewSimulationRequest` and `NewSimulationResponse` structures in order to be able to use them in the unit tests for assertions and request creation. 

We may also want to implement specific unit tests for api instead of testing just the endpoints.
