### PR TITLE
Add start endpoint API + test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
-# barnes-hut-sim
-A Go implementation of a Barnes–Hut simulation.
+# Barnes Hut Simulator  
+
+A Go implementation of a Barnes–Hut simulation, it allows you to start a server which has an HTTP API which allows you to create and run multiple simulations.
+
+## Server
+The server resides at `/cmd/server/main.go`
+
+## Server Api
+### Create new Sim
+**POST** /simulation/new
+
+This request should return a `simID`
+
+### Start Sim
+**GET** /simulation/start/**simID**/**steps**
+- `simID`: the ID of the sim you want to start
+- `steps`: the number of steps you want the sim to run for
+
+### Sim Status
+**GET** /simulation/status/**SimID**
+- `simID`: the ID of the sim you want the status for
+
+### Sim Results
+**GET** /simulation/results/**SimID**
+- `simID`: the ID of the sim you want results for
+
+### Sim Remove
+**GET** /simulation/remove/**SimID**
+- `simID`: the ID of the sim you want to remove
+
+## Code Examples 
+Some examples can be found in `/cmd/examples`
+
+<img align="right" alt="Github Stats" src="https://github-readme-stats.vercel.app/api?username=tardisman5197&show_icons=true&hide_border=true&count_private=true" />

--- a/cmd/server/api/api.go
+++ b/cmd/server/api/api.go
@@ -15,7 +15,7 @@ import (
 type API struct {
 	server *http.Server
 
-	mutex       *sync.Mutex
+	mutex       *sync.RWMutex
 	simulations map[string]simulation.Simulation
 }
 
@@ -23,7 +23,7 @@ type API struct {
 func NewAPI() API {
 	var a API
 	a.setup()
-	a.mutex = &sync.Mutex{}
+	a.mutex = &sync.RWMutex{}
 	a.simulations = make(map[string]simulation.Simulation)
 	return a
 }

--- a/cmd/server/api/endpoints.go
+++ b/cmd/server/api/endpoints.go
@@ -80,9 +80,6 @@ func (a *API) newSimulation(w http.ResponseWriter, r *http.Request) {
 func (a *API) start(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.URL.Path)
 
-	a.mutex.RLock()
-	defer a.mutex.RUnlock()
-
 	// Retrieve path parameters
 	vars := mux.Vars(r)
 	simID := vars["simID"]
@@ -98,11 +95,13 @@ func (a *API) start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	a.mutex.RLock()
 	// Check if a simulation has been created before
 	if _, ok := a.simulations[simID]; !ok {
 		http.Error(w, fmt.Errorf("there is no simulation with the simID %s", simID).Error(), http.StatusNotFound)
 		return
 	}
+	a.mutex.RUnlock()
 
 	// Steps must be positive
 	if steps <= 0 {

--- a/cmd/server/api/endpoints.go
+++ b/cmd/server/api/endpoints.go
@@ -79,9 +79,6 @@ func (a *API) newSimulation(w http.ResponseWriter, r *http.Request) {
 func (a *API) start(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.URL.Path)
 
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-
 	// Retrieve path parameters
 	vars := mux.Vars(r)
 	simID := vars["simID"]

--- a/cmd/server/api/endpoints_test.go
+++ b/cmd/server/api/endpoints_test.go
@@ -78,6 +78,7 @@ func TestMain(m *testing.M) {
 
 func TestStart(t *testing.T) {
 	for _, test := range testsStart {
+		t.Logf("Test case: %s", test.description)
 		r, err := http.Get(StartURL + test.given)
 		if err != nil {
 			t.Fatal(err)

--- a/cmd/server/api/endpoints_test.go
+++ b/cmd/server/api/endpoints_test.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/tardisman5197/barnes-hut-sim/pkg/simulation"
+)
+
+const (
+	BaseURL  string = "http://localhost:5000/simulation"
+	NewURL   string = BaseURL + "/new"
+	StartURL string = BaseURL + "/start"
+)
+
+var testsStart = []struct {
+	expected    int
+	given       string
+	description string
+}{
+	{expected: http.StatusNotFound, given: "/t/10", description: "Non-existent simulation"},
+}
+
+var simul = simulation.Simulation{
+	Grav:  9.81,
+	Theta: 0.1,
+	Bodies: []simulation.Body{
+		{Name: "Hi", X: 10.0, Y: 10.0, Z: 10.0, Radius: 1, Density: 1},
+		{Name: "stuff", X: 1.0, Y: 10.0, Z: 1.0, Radius: 1, Density: 1},
+	},
+}
+
+func addSimul() {
+	body, err := json.Marshal(simul)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a dummy simulation to test on an existing one
+	r, err := http.Post(NewURL, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		panic(err)
+	}
+	defer r.Body.Close()
+
+	var res struct {
+		ID         string                `json:"id"`
+		Simulation simulation.Simulation `json:"simulation"`
+	}
+
+	err = json.NewDecoder(r.Body).Decode(&res)
+	if err != nil {
+		panic(err)
+	}
+
+	testsStart = append(testsStart, []struct {
+		expected    int
+		given       string
+		description string
+	}{
+		{expected: http.StatusOK, given: fmt.Sprintf("/%s/10", res.ID), description: "Normal use"},
+		{expected: http.StatusBadRequest, given: fmt.Sprintf("/%s/-1", res.ID), description: "Negative number of steps"},
+		{expected: http.StatusBadRequest, given: fmt.Sprintf("/%s/t", res.ID), description: "Non digit steps"},
+	}...)
+}
+
+func TestMain(m *testing.M) {
+	a := NewAPI()
+	a.Listen()
+	addSimul()
+
+	os.Exit(m.Run())
+}
+
+func TestStart(t *testing.T) {
+	for _, test := range testsStart {
+		r, err := http.Get(StartURL + test.given)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer r.Body.Close()
+
+		if r.StatusCode != test.expected {
+			t.Fatalf("%s%s: expected %d, got %d", StartURL, test.given, test.expected, r.StatusCode)
+		}
+	}
+}


### PR DESCRIPTION
Solves #10 

This pull request implements the `/simulation/start` endpoint of the API with testing.

The status codes returned by the endpoint are the following:
- `404 Not Found` if the simID parameter provided does not correspond to an existing simulation.
- `400 Bad Request` if the steps parameter provided is not an integer or is negative or null.
- `200 OK` If everything goes fine and the steps are performed.

As a result of successful execution the following format is returned to the client:
```
{
    "id": // id of the simulation
    "bodies": // array of bodies status as they are in the last step
}
```

The unit tests reproduce basic behaviors that can be done on the endpoint as stated as improvement in #16 
I'm not sure about all the test cases if there are some missing.

The `StartSimulationResponse` type has been added to the list and has been documented.