### PR TITLE
Add functionality for /status endpoint

### DIFF
--- a/cmd/server/api/api.go
+++ b/cmd/server/api/api.go
@@ -16,7 +16,7 @@ type API struct {
 	server *http.Server
 
 	mutex       *sync.RWMutex
-	simulations map[string]simulation.Simulation
+	simulations map[string]*simulation.Simulation
 }
 
 // NewAPI returns an instance of an API struct.
@@ -24,7 +24,7 @@ func NewAPI() API {
 	var a API
 	a.setup()
 	a.mutex = &sync.RWMutex{}
-	a.simulations = make(map[string]simulation.Simulation)
+	a.simulations = make(map[string]*simulation.Simulation)
 	return a
 }
 

--- a/pkg/simulation/simulation.go
+++ b/pkg/simulation/simulation.go
@@ -23,8 +23,8 @@ type Simulation struct {
 // NewSimulation returns an instance of a Simulation
 // struct. It initilises some simulation paramaters
 // and can optionally set the bodies for the simulation.
-func NewSimulation(grav, theta float64, bodies ...Body) Simulation {
-	return Simulation{
+func NewSimulation(grav, theta float64, bodies ...Body) *Simulation {
+	return &Simulation{
 		Grav:   grav,
 		Theta:  theta,
 		Bodies: bodies,


### PR DESCRIPTION
Issue : #11 

Add new functionality to provide status for running process via `/status` endpoint.

Existing code need to be modified to allow updates of the steps