### PR TITLE
implemented results endpoint with tests

### DIFF
--- a/cmd/server/api/api.go
+++ b/cmd/server/api/api.go
@@ -28,15 +28,19 @@ func NewAPI() API {
 	return a
 }
 
-// setup creates the http server.
-func (a *API) setup() {
+func (a *API) router() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/simulation/new", a.newSimulation).Methods("POST")
 	r.HandleFunc("/simulation/start/{simID}/{steps}", a.start).Methods("GET")
 	r.HandleFunc("/simulation/status/{simID}", a.status).Methods("GET")
 	r.HandleFunc("/simulation/results/{simID}", a.results).Methods("GET")
 	r.HandleFunc("/simulation/remove/{simID}", a.remove).Methods("GET")
+	return r
+}
 
+// setup creates the http server.
+func (a *API) setup() {
+	r := a.router()
 	a.server = &http.Server{
 		Handler:      r,
 		Addr:         ":5000",

--- a/cmd/server/api/api_test.go
+++ b/cmd/server/api/api_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -56,7 +57,7 @@ func TestEndpointCreateSimulation(t *testing.T) {
 	}
 
 	currentSimulations := len(api.simulations)
-	if currentSimulations != 1{
+	if currentSimulations != 1 {
 		t.Fatalf("expected 1 simulation, found %d", currentSimulations)
 	}
 
@@ -98,7 +99,7 @@ func TestEndpointRemoveSimulation(t *testing.T) {
 	}
 
 	currentSimulations := len(api.simulations)
-	if currentSimulations != 1{
+	if currentSimulations != 1 {
 		t.Fatalf("expected 1 simulation, found %d", currentSimulations)
 	}
 
@@ -125,9 +126,34 @@ func TestEndpointRemoveSimulation(t *testing.T) {
 
 func TestRemoveNotPresentSimulation(t *testing.T) {
 	api := NewAPI()
+
+	reqBody := NewSimulationRequest{
+		Grav:   1,
+		Theta:  0,
+		Bodies: []simulation.Body{},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := &http.Request{
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(bytes.NewBuffer(body)),
+	}
+
 	rr := httptest.NewRecorder()
 
-	request := mux.SetURLVars(&http.Request{
+	api.newSimulation(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	rr = httptest.NewRecorder()
+
+	request = mux.SetURLVars(&http.Request{
 		Method: http.MethodGet,
 	}, map[string]string{
 		"simID": "test",
@@ -155,4 +181,86 @@ func TestRemoveWithoutSimID(t *testing.T) {
 	}
 }
 
+func TestSimulationStatusEndpoint(t *testing.T) {
+	api := NewAPI()
 
+	reqBody := NewSimulationRequest{
+		Grav:   1,
+		Theta:  0,
+		Bodies: []simulation.Body{},
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	request := &http.Request{
+		Method: http.MethodPost,
+		Body:   ioutil.NopCloser(bytes.NewBuffer(body)),
+	}
+
+	rr := httptest.NewRecorder()
+
+	api.newSimulation(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	var response NewSimulationResponse
+	if err := json.NewDecoder(rr.Result().Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+
+	if response.ID == "" {
+		t.Fatal("empty simulation ID")
+	}
+
+	rr = httptest.NewRecorder()
+
+	request = mux.SetURLVars(&http.Request{
+		Method: http.MethodGet,
+	}, map[string]string{
+		"simID": response.ID,
+	})
+
+	api.results(rr, request)
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusOK)
+	}
+
+	var resultResponse simulationResultResponse
+	if err := json.NewDecoder(rr.Result().Body).Decode(&resultResponse); err != nil {
+		t.Fatal(err)
+	}
+
+	if resultResponse.Simulation.Grav != reqBody.Grav {
+		t.Fatalf("unexpected simulation Grav value %f != %f", resultResponse.Simulation.Grav, reqBody.Grav)
+	}
+
+	if resultResponse.Simulation.Theta != reqBody.Theta {
+		t.Fatalf("unexpected simulation Theta value %f != %f", resultResponse.Simulation.Theta, reqBody.Theta)
+	}
+
+	if reflect.DeepEqual(resultResponse.Simulation.Bodies, reqBody.Bodies) {
+		t.Fatalf("unexpected simulation Bodies values")
+	}
+
+}
+
+func TestSimulationStatusEndpointWithoutSimID(t *testing.T) {
+	api := NewAPI()
+	rr := httptest.NewRecorder()
+
+	request := mux.SetURLVars(&http.Request{
+		Method: http.MethodGet,
+	}, map[string]string{})
+
+	api.results(rr, request)
+
+	if rr.Result().StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d != %d", rr.Result().StatusCode, http.StatusBadRequest)
+	}
+}

--- a/cmd/server/api/endpoints_test.go
+++ b/cmd/server/api/endpoints_test.go
@@ -5,16 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/tardisman5197/barnes-hut-sim/pkg/simulation"
 )
 
 const (
-	BaseURL  string = "http://localhost:5000/simulation"
-	NewURL   string = BaseURL + "/new"
-	StartURL string = BaseURL + "/start"
+	StartURL string = "/start"
 )
 
 var testsStart = []struct {
@@ -34,14 +32,14 @@ var simul = simulation.Simulation{
 	},
 }
 
-func addSimul() {
+func addSimul(baseUrl string) {
 	body, err := json.Marshal(simul)
 	if err != nil {
 		panic(err)
 	}
 
 	// Create a dummy simulation to test on an existing one
-	r, err := http.Post(NewURL, "application/json", bytes.NewBuffer(body))
+	r, err := http.Post(baseUrl+"/new", "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		panic(err)
 	}
@@ -68,25 +66,99 @@ func addSimul() {
 	}...)
 }
 
-func TestMain(m *testing.M) {
-	a := NewAPI()
-	a.Listen()
-	addSimul()
-
-	os.Exit(m.Run())
-}
-
 func TestStart(t *testing.T) {
+	api := NewAPI()
+	srv := httptest.NewServer(api.router())
+	defer srv.Close()
+
+	simulationEndpoint := srv.URL + "/simulation"
+	addSimul(simulationEndpoint)
+
 	for _, test := range testsStart {
 		t.Logf("Test case: %s", test.description)
-		r, err := http.Get(StartURL + test.given)
+		r, err := http.Get(simulationEndpoint + StartURL + test.given)
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer r.Body.Close()
 
 		if r.StatusCode != test.expected {
 			t.Fatalf("%s%s: expected %d, got %d", StartURL, test.given, test.expected, r.StatusCode)
 		}
+
+		if err := r.Body.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestStatusApi(t *testing.T) {
+	api := NewAPI()
+	srv := httptest.NewServer(api.router())
+	defer srv.Close()
+
+	inputSimulation := simulation.Simulation{
+		Grav:  9.81,
+		Theta: 31,
+		Bodies: []simulation.Body{
+			{
+				Name:    "test",
+				X:       1,
+				Y:       2,
+				Z:       3,
+				Radius:  4,
+				Density: 5,
+			},
+		},
+	}
+	api.simulations["test_id"] = inputSimulation
+
+	resp, err := http.Get(srv.URL + "/simulation/results/test_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code %d != %d", resp.StatusCode, http.StatusOK)
+	}
+
+	var resultResponse simulationResultResponse
+	if err := json.NewDecoder(resp.Body).Decode(&resultResponse); err != nil {
+		t.Fatal(err)
+	}
+
+	if resultResponse.Simulation.Grav != inputSimulation.Grav {
+		t.Fatalf("unexpected simulation Grav value %f != %f", resultResponse.Simulation.Grav, inputSimulation.Grav)
+	}
+
+	if resultResponse.Simulation.Theta != inputSimulation.Theta {
+		t.Fatalf("unexpected simulation Theta value %f != %f", resultResponse.Simulation.Theta, inputSimulation.Theta)
+	}
+
+	if len(resultResponse.Simulation.Bodies) != len(inputSimulation.Bodies) {
+		t.Fatalf("unexpected simulation Bodies len")
+	}
+
+	if resultResponse.Simulation.Bodies[0] != inputSimulation.Bodies[0] {
+		t.Fatalf("unexpected simulation Bodies values")
+	}
+
+}
+
+func TestStatusApiWithInvalidSimID(t *testing.T) {
+	api := NewAPI()
+	srv := httptest.NewServer(api.router())
+	defer srv.Close()
+
+	api.simulations["test_id"] = simulation.Simulation{}
+
+	resp, err := http.Get(srv.URL + "/simulation/results/invalid_test_id")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("unexpected status code %d != %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }


### PR DESCRIPTION
Solves #12 

This implement results endpoint with tests, it also provide a minor refactor to the Api struct so we are now able to test request routing as discussed with @tardisman5197 in #16  using the go httptests package.

I also refactored previous tests eg: `TestStart` to use the new methodology, so we can also run tests in parallel and not bind then on port 5000 that may cause nasty issues.

Is not possible to test the api with endpoint as following:

```golang
func TestExample(t *testing.T) {
	api := NewAPI()
	srv := httptest.NewServer(api.router())
	defer srv.Close()
	api.simulations["test_id"] = simulation.Simulation{}
	resp, err := http.Get(srv.URL + "/simulation/results/id")
        // assertions 
}
```